### PR TITLE
사용자 및 프로필에 대한 도메인 및 서비스 로직 구성

### DIFF
--- a/src/main/java/com/fit_us/web/common/entity/BaseEntity.java
+++ b/src/main/java/com/fit_us/web/common/entity/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.fit_us.web.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @CreationTimestamp
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/fit_us/web/common/entity/BaseEntityWithUpdate.java
+++ b/src/main/java/com/fit_us/web/common/entity/BaseEntityWithUpdate.java
@@ -1,0 +1,17 @@
+package com.fit_us.web.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntityWithUpdate extends BaseEntity {
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fit_us/web/common/utility/DateUtils.java
+++ b/src/main/java/com/fit_us/web/common/utility/DateUtils.java
@@ -1,0 +1,9 @@
+package com.fit_us.web.common.utility;
+
+import java.time.LocalDate;
+
+public class DateUtils {
+    public static LocalDate parseDate(String date){
+        return LocalDate.parse(date);
+    }
+}

--- a/src/main/java/com/fit_us/web/user/application/UserService.java
+++ b/src/main/java/com/fit_us/web/user/application/UserService.java
@@ -1,0 +1,11 @@
+package com.fit_us.web.user.application;
+
+import com.fit_us.web.user.application.dto.CreateUserCommand;
+import com.fit_us.web.user.domain.User;
+
+public interface UserService {
+    User create(CreateUserCommand command);
+    User update(Long id);
+    void delete(Long id);
+
+}

--- a/src/main/java/com/fit_us/web/user/application/UserService.java
+++ b/src/main/java/com/fit_us/web/user/application/UserService.java
@@ -5,7 +5,6 @@ import com.fit_us.web.user.domain.User;
 
 public interface UserService {
     User create(CreateUserCommand command);
-    User update(Long id);
     void delete(Long id);
 
 }

--- a/src/main/java/com/fit_us/web/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fit_us/web/user/application/UserServiceImpl.java
@@ -1,0 +1,58 @@
+package com.fit_us.web.user.application;
+
+import com.fit_us.web.user.application.dto.CreateUserCommand;
+import com.fit_us.web.user.domain.Profile;
+import com.fit_us.web.user.domain.User;
+import com.fit_us.web.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public User create(CreateUserCommand command) {
+        User newUser = createUser(command);
+        Profile newProfile = createProfile(command.getProfile());
+        newUser.addProfile(newProfile);
+        return userRepository.save(newUser);
+    }
+
+    @Override
+    public User update(Long id) {
+        return null;
+    }
+
+    @Override
+    public void delete(Long id) {
+    }
+    private User createUser(CreateUserCommand command) {
+        if(command == null){
+            throw new IllegalArgumentException("CreateUserCommand cannot be null.");
+        }
+        return User.create(
+                command.getName(),
+                command.getNickname(),
+                command.getOauthId(),
+                command.getProvider(),
+                command.getEmail()
+        );
+    }
+
+    private Profile createProfile(CreateUserCommand.ProfileInfo command) {
+        if(command == null){
+            throw new  IllegalArgumentException("Profile information cannot be null.");
+        }
+        return Profile.create(
+                command.getProfileImageUrl(),
+                command.getBirthDate(),
+                command.getGender(),
+                command.getBloodType()
+        );
+    }
+}

--- a/src/main/java/com/fit_us/web/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fit_us/web/user/application/UserServiceImpl.java
@@ -22,14 +22,11 @@ public class UserServiceImpl implements UserService{
         newUser.addProfile(newProfile);
         return userRepository.save(newUser);
     }
-
-    @Override
-    public User update(Long id) {
-        return null;
-    }
-
     @Override
     public void delete(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(()->new IllegalArgumentException("cannot found user"));
+        user.delete();
     }
     private User createUser(CreateUserCommand command) {
         if(command == null){

--- a/src/main/java/com/fit_us/web/user/application/dto/CreateUserCommand.java
+++ b/src/main/java/com/fit_us/web/user/application/dto/CreateUserCommand.java
@@ -1,0 +1,26 @@
+package com.fit_us.web.user.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class CreateUserCommand {
+    String name;
+    String nickname;
+    String oauthId;
+    String provider;
+    String email;
+    ProfileInfo profile;
+    @Getter
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    public static class ProfileInfo {
+        private String profileImageUrl;
+        private String birthDate;
+        private String gender;
+        private String bloodType;
+    }
+}

--- a/src/main/java/com/fit_us/web/user/application/dto/UserDtoMapper.java
+++ b/src/main/java/com/fit_us/web/user/application/dto/UserDtoMapper.java
@@ -1,0 +1,41 @@
+package com.fit_us.web.user.application.dto;
+
+import com.fit_us.web.user.domain.Profile;
+import com.fit_us.web.user.domain.User;
+import com.fit_us.web.user.presentation.dto.UserResponse;
+
+import java.time.format.DateTimeFormatter;
+
+public class UserDtoMapper {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    /**
+     * 도메인 User 객체를 UserResponse DTO로 변환
+     */
+    public static UserResponse toResponse(User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null.");
+        }
+
+        UserResponse.ProfileInfo profileInfo = null;
+        Profile profile = user.getProfile();
+        if (profile != null) {
+            profileInfo = new UserResponse.ProfileInfo(
+                    profile.getProfileImageUrl(),
+                    profile.getBirthDate().format(DATE_FORMATTER),
+                    profile.getGender().name(),
+                    profile.getBloodType().name()
+            );
+        }
+
+        return new UserResponse(
+                user.getProvider(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail(),
+                profileInfo
+        );
+    }
+}
+

--- a/src/main/java/com/fit_us/web/user/domain/BloodType.java
+++ b/src/main/java/com/fit_us/web/user/domain/BloodType.java
@@ -1,0 +1,12 @@
+package com.fit_us.web.user.domain;
+
+public enum BloodType {
+    RH_PLUS_A, RH_MINUS_A,
+    RH_PLUS_B, RH_MINUS_B,
+    RH_PLUS_AB, RH_MINUS_AB,
+    RH_PLUS_O, RH_MINUS_O;
+
+    public static BloodType parse(String bloodType){
+        return BloodType.valueOf(bloodType.toUpperCase());
+    }
+}

--- a/src/main/java/com/fit_us/web/user/domain/Gender.java
+++ b/src/main/java/com/fit_us/web/user/domain/Gender.java
@@ -1,0 +1,8 @@
+package com.fit_us.web.user.domain;
+
+public enum Gender {
+    MALE, FEMALE;
+    public static Gender parse(String gender){
+        return Gender.valueOf(gender.toUpperCase());
+    }
+}

--- a/src/main/java/com/fit_us/web/user/domain/Profile.java
+++ b/src/main/java/com/fit_us/web/user/domain/Profile.java
@@ -1,0 +1,53 @@
+package com.fit_us.web.user.domain;
+
+import com.fit_us.web.common.entity.BaseEntity;
+import com.fit_us.web.common.utility.DateUtils;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity(name = "profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+public class Profile extends BaseEntity {
+    @Column(nullable = false)
+    private String profileImageUrl;
+
+    @Column(nullable = false)
+    private LocalDate birthDate;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BloodType bloodType;
+
+    public static Profile create(String profileImageUrl, String birthDate, String gender, String bloodType) {
+        LocalDate parsedBirthDate = DateUtils.parseDate(birthDate);
+        Gender parsedGender = Gender.parse(gender);
+        BloodType parsedBloodType = BloodType.parse(bloodType);
+
+        return builder()
+                .profileImageUrl(profileImageUrl)
+                .birthDate(parsedBirthDate)
+                .gender(parsedGender)
+                .bloodType(parsedBloodType)
+                .build();
+    }
+
+    /**
+     * 생년월일
+     * 성별
+     * 혈액형
+     * 프로필 사진
+     * 감정기록 설정
+     * 약 복용 유무
+     * 정병 자가문진 했
+     */
+
+}

--- a/src/main/java/com/fit_us/web/user/domain/Profile.java
+++ b/src/main/java/com/fit_us/web/user/domain/Profile.java
@@ -2,7 +2,10 @@ package com.fit_us.web.user.domain;
 
 import com.fit_us.web.common.entity.BaseEntity;
 import com.fit_us.web.common.utility.DateUtils;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -39,7 +42,6 @@ public class Profile extends BaseEntity {
                 .bloodType(parsedBloodType)
                 .build();
     }
-
     /**
      * 생년월일
      * 성별

--- a/src/main/java/com/fit_us/web/user/domain/User.java
+++ b/src/main/java/com/fit_us/web/user/domain/User.java
@@ -3,6 +3,11 @@ package com.fit_us.web.user.domain;
 import com.fit_us.web.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import java.time.LocalDateTime;
 
 /**
  * Oauth 기반으로
@@ -35,6 +40,10 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.EAGER)
     private Profile profile;
 
+    @Builder.Default
+    @Column(nullable = true, name = "deleted_at")
+    private LocalDateTime deletedAt = null;
+
     public static User create(String name, String nickname, String oauthId, String provider, String email) {
         return builder()
                 .name(name)
@@ -49,5 +58,11 @@ public class User extends BaseEntity {
             throw new IllegalStateException("Profile already exists for this user.");
         }
         this.profile = profile;
+    }
+    public void delete() {
+        if (this.deletedAt != null) {
+            throw new IllegalStateException("User is already deleted.");
+        }
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/fit_us/web/user/domain/User.java
+++ b/src/main/java/com/fit_us/web/user/domain/User.java
@@ -1,0 +1,53 @@
+package com.fit_us.web.user.domain;
+
+import com.fit_us.web.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Oauth 기반으로
+ */
+
+@Entity(name="users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String oauthId;
+
+    /*
+       auth 도메인에서 enum으로 검증하기 떄문에 여기서는 String으로 처리해도  됨.
+     */
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    private Profile profile;
+
+    public static User create(String name, String nickname, String oauthId, String provider, String email) {
+        return builder()
+                .name(name)
+                .nickname(nickname)
+                .oauthId(oauthId)
+                .provider(provider)
+                .email(email)
+                .build();
+    }
+    public void addProfile(Profile profile) {
+        if (this.profile != null) {
+            throw new IllegalStateException("Profile already exists for this user.");
+        }
+        this.profile = profile;
+    }
+}

--- a/src/main/java/com/fit_us/web/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/fit_us/web/user/infrastructure/UserRepository.java
@@ -1,0 +1,7 @@
+package com.fit_us.web.user.infrastructure;
+
+import com.fit_us.web.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/fit_us/web/user/presentation/UserController.java
+++ b/src/main/java/com/fit_us/web/user/presentation/UserController.java
@@ -1,0 +1,36 @@
+package com.fit_us.web.user.presentation;
+
+import com.fit_us.web.user.application.UserService;
+import com.fit_us.web.user.application.dto.CreateUserCommand;
+import com.fit_us.web.user.application.dto.UserDtoMapper;
+import com.fit_us.web.user.domain.User;
+import com.fit_us.web.user.presentation.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    /**
+     * 추 후, auth에서 받고 event driven으로 처리해도 될듯
+     */
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    UserResponse createUser(@RequestBody CreateUserCommand command){
+        User user = userService.create(command);
+        return UserDtoMapper.toResponse(user);
+    }
+    @PatchMapping()
+    ResponseEntity<Void> updateUser(){
+        return null;
+    }
+    @DeleteMapping()
+    ResponseEntity<Void> deleteUser(){
+        return null;
+    }
+}

--- a/src/main/java/com/fit_us/web/user/presentation/dto/UserResponse.java
+++ b/src/main/java/com/fit_us/web/user/presentation/dto/UserResponse.java
@@ -1,0 +1,23 @@
+package com.fit_us.web.user.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+    private String provider;
+    private String name;
+    private String nickname;
+    private String email;
+    private ProfileInfo profile;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ProfileInfo {
+        private String profileImageUrl;
+        private String birthDate; // "yyyy-MM-dd" 형식의 문자열
+        private String gender;
+        private String bloodType;
+    }
+}


### PR DESCRIPTION
## 😎 연결 된 이슈
- #4 

## **📌 주요 사항**  
- **사용자(User) 및 프로필(Profile) 도메인 추가** (`deleted_at` 필드로 소프트 삭제 적용)  
- **UserService 및 UserRepository 추가** (사용자 생성 및 삭제 기능 구현)  
- **UserDtoMapper 및 DTO 추가** (`UserResponse`, `UserCreateCommand`)  
- **사용자 API (`UserController`) 구현**
- **리팩토링**: `update()` 제거, 삭제 기능 수정