### PR TITLE
순간 감정 상태에 대한 도메인 및 서비스 로직 구성

### DIFF
--- a/src/main/java/com/fit_us/web/emotion/application/EmotionLogService.java
+++ b/src/main/java/com/fit_us/web/emotion/application/EmotionLogService.java
@@ -1,0 +1,11 @@
+    package com.fit_us.web.emotion.application;
+
+    import com.fit_us.web.emotion.domain.EmotionLog;
+    import com.fit_us.web.emotion.application.dto.CreateEmotionLogCommand;
+
+    import java.util.List;
+
+    public interface EmotionLogService {
+        EmotionLog create(CreateEmotionLogCommand command);
+        List<EmotionLog> findAll();
+    }

--- a/src/main/java/com/fit_us/web/emotion/application/EmotionLogServiceImpl.java
+++ b/src/main/java/com/fit_us/web/emotion/application/EmotionLogServiceImpl.java
@@ -1,0 +1,35 @@
+package com.fit_us.web.emotion.application;
+
+import com.fit_us.web.emotion.domain.EmotionLog;
+import com.fit_us.web.emotion.infrastructure.EmotionLogRepository;
+import com.fit_us.web.emotion.application.dto.CreateEmotionLogCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionLogServiceImpl implements EmotionLogService{
+    private final EmotionLogRepository emotionLogRepository;
+
+    /**
+     * TODO:
+     * 유저에 대한 형식으로 변경 필요
+     */
+    @Override
+    public EmotionLog create(CreateEmotionLogCommand command) {
+        EmotionLog newEmotionLog = EmotionLog.create(
+                command.getEmotionLevel(),
+                command.getKeywords(),
+                command.getLocation(),
+                command.getSituation());
+
+        return emotionLogRepository.save(newEmotionLog);
+    }
+
+    @Override
+    public List<EmotionLog> findAll() {
+        return emotionLogRepository.findAll();
+    }
+}

--- a/src/main/java/com/fit_us/web/emotion/application/dto/CreateEmotionLogCommand.java
+++ b/src/main/java/com/fit_us/web/emotion/application/dto/CreateEmotionLogCommand.java
@@ -1,0 +1,15 @@
+package com.fit_us.web.emotion.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateEmotionLogCommand {
+    private String emotionLevel;
+    private List<String> keywords;
+    private String location;
+    private String situation;
+}

--- a/src/main/java/com/fit_us/web/emotion/application/dto/EmotionLogDtoMapper.java
+++ b/src/main/java/com/fit_us/web/emotion/application/dto/EmotionLogDtoMapper.java
@@ -1,0 +1,28 @@
+package com.fit_us.web.emotion.application.dto;
+
+import com.fit_us.web.emotion.domain.EmotionLog;
+import com.fit_us.web.emotion.presentation.dto.EmotionLogResponse;
+
+import java.util.List;
+
+public class EmotionLogDtoMapper  {
+
+    public static EmotionLogResponse toResponse(EmotionLog emotionLog){
+        if(emotionLog == null){
+            throw  new IllegalArgumentException("EmotionLog cannot be null. ");
+        }
+        return new EmotionLogResponse(
+                emotionLog.getId(),
+                emotionLog.getEmotionLevel(),
+                emotionLog.getKeywords(),
+                emotionLog.getLocation(),
+                emotionLog.getSituation()
+        );
+    }
+
+    public static List<EmotionLogResponse> toResponseList(List<EmotionLog> emotionLogs){
+        return emotionLogs.stream()
+                .map(EmotionLogDtoMapper::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/fit_us/web/emotion/domain/EmotionLevel.java
+++ b/src/main/java/com/fit_us/web/emotion/domain/EmotionLevel.java
@@ -1,0 +1,25 @@
+package com.fit_us.web.emotion.domain;
+
+public enum EmotionLevel {
+    VERY_UNHAPPY("매우 불쾌함"),
+    UNHAPPY("불쾌함"),
+    NEUTRAL("보통"),
+    SLIGHTLY_HAPPY("약간 기분 좋음"),
+    HAPPY("기분 좋음"),
+    VERY_HAPPY("매우 기분 좋음");
+
+    private final String description;
+
+    EmotionLevel(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static EmotionLevel parse(String emotionLevel){
+        return EmotionLevel.valueOf(emotionLevel.toUpperCase());
+    }
+}
+

--- a/src/main/java/com/fit_us/web/emotion/domain/EmotionLog.java
+++ b/src/main/java/com/fit_us/web/emotion/domain/EmotionLog.java
@@ -1,0 +1,40 @@
+package com.fit_us.web.emotion.domain;
+
+import com.fit_us.web.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity(name = "emotion_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+
+public class EmotionLog extends BaseEntity {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionLevel emotionLevel;
+
+    @ElementCollection
+    @CollectionTable(name = "emotion_keywords", joinColumns = @JoinColumn(name = "emotion_log_id"))
+    @Column(name = "keyword")
+    private List<String> keywords;
+
+    @Column(nullable = true)
+    private String location;
+
+    @Column(nullable = true, length = 500)
+    private String situation;
+
+    public static EmotionLog create(String emotionLevel, List<String> keywords, String location, String situation) {
+        EmotionLevel parsedEmotionLevel = EmotionLevel.parse(emotionLevel);
+        return EmotionLog.builder()
+                .emotionLevel(parsedEmotionLevel)
+                .keywords(keywords)
+                .location(location)
+                .situation(situation)
+                .build();
+    }
+}

--- a/src/main/java/com/fit_us/web/emotion/infrastructure/EmotionLogRepository.java
+++ b/src/main/java/com/fit_us/web/emotion/infrastructure/EmotionLogRepository.java
@@ -1,0 +1,7 @@
+package com.fit_us.web.emotion.infrastructure;
+
+import com.fit_us.web.emotion.domain.EmotionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionLogRepository extends JpaRepository<EmotionLog, Long> {
+}

--- a/src/main/java/com/fit_us/web/emotion/presentation/EmotionLogController.java
+++ b/src/main/java/com/fit_us/web/emotion/presentation/EmotionLogController.java
@@ -1,0 +1,34 @@
+package com.fit_us.web.emotion.presentation;
+
+import com.fit_us.web.emotion.application.EmotionLogService;
+import com.fit_us.web.emotion.application.dto.CreateEmotionLogCommand;
+import com.fit_us.web.emotion.application.dto.EmotionLogDtoMapper;
+import com.fit_us.web.emotion.domain.EmotionLog;
+import com.fit_us.web.emotion.presentation.dto.EmotionLogResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class EmotionLogController {
+    /**
+     * CR
+     */
+    private final EmotionLogService emotionLogService;
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    EmotionLogResponse createEmotionLog(@RequestBody CreateEmotionLogCommand command){
+        EmotionLog emotionLog = emotionLogService.create(command);
+        return EmotionLogDtoMapper.toResponse(emotionLog);
+    }
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    List<EmotionLogResponse> findAllEmotionLogs(){
+        List<EmotionLog> emotionLogs = emotionLogService.findAll();
+        return EmotionLogDtoMapper.toResponseList(emotionLogs);
+    }
+}

--- a/src/main/java/com/fit_us/web/emotion/presentation/dto/EmotionLogResponse.java
+++ b/src/main/java/com/fit_us/web/emotion/presentation/dto/EmotionLogResponse.java
@@ -1,0 +1,8 @@
+package com.fit_us.web.emotion.presentation.dto;
+
+import com.fit_us.web.emotion.domain.EmotionLevel;
+
+import java.util.List;
+
+public record EmotionLogResponse(Long id, EmotionLevel emotionLevel, List<String> keywords, String location, String situation) {
+}


### PR DESCRIPTION
## 😎 연결 된 이슈
- #5 

## 📖추가 된 내용
- **감정 로그 열거형**: 감정 상태를 정의하는 열거형 추가.
- **EmotionLogRepository 인터페이스**: 감정 로그 데이터를 처리할 리포지토리 인터페이스 추가.
- **EmotionLogService 인터페이스**: 감정 로그 서비스 관련 기능을 정의한 인터페이스 추가.
- **EmotionLogServiceImpl 클래스**: 감정 로그 생성 및 조회 기능을 구현한 서비스 클래스 추가.
- **CreateEmotionLogCommand DTO 클래스**: 감정 로그 생성에 필요한 데이터를 전달하기 위한 DTO 클래스 추가.
- **EmotionLogDtoMapper 클래스**: `EmotionLog` 객체를 `EmotionLogResponse` 객체로 변환하는 매퍼 클래스 추가.
- **EmotionLogController 클래스**: 감정 로그를 생성하고 조회하는 API 구현을 위한 컨트롤러 클래스 추가.
- **EmotionLogResponse DTO 클래스**: 감정 로그 응답을 위한 DTO 클래스 추가.

### ✏️변경 사항 요약:
- 감정 로그 관련 서비스 및 API를 추가하여 감정 로그의 생성과 조회 기능을 지원합니다.
- 필요한 DTO 및 매퍼를 추가하여 데이터 변환 및 응답 처리 기능을 구현하였습니다.